### PR TITLE
Display question text below learning mode header

### DIFF
--- a/app.py
+++ b/app.py
@@ -803,6 +803,7 @@ def render_learning(db: DBManager) -> None:
     row = filtered[filtered["id"] == question_id].iloc[0]
     st.subheader(f"{row['year']}年 問{row['q_no']}")
     st.markdown(f"**{row['category']} / {row['topic']}**")
+    st.markdown(row["question"], unsafe_allow_html=True)
     choices = [row[f"choice{i}"] for i in range(1, 5)]
     if st.session_state["settings"].get("shuffle_choices", True):
         random.seed(question_id)


### PR DESCRIPTION
## Summary
- render the selected question's text in the learning mode view so it appears below the title and category

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db43addeec8323862f3e8316517b93