### PR TITLE
Fix confidence slider state handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1421,7 +1421,11 @@ def render_question_interaction(
                     selected_choice = actual_idx
                 st.markdown("</div>", unsafe_allow_html=True)
     st.caption("1〜4キーで選択肢を即答できます。E:解説 F:フラグ N/P:移動 H:ヘルプ")
-    confidence_value = st.session_state.get(confidence_key, 50)
+    confidence_value = st.session_state.get(confidence_key)
+    if confidence_value is None:
+        confidence_value = 50
+    else:
+        confidence_value = int(confidence_value)
     confidence_value = st.slider(
         "確信度（ぜんぜん自信なし ↔ 完璧）",
         0,
@@ -1429,7 +1433,6 @@ def render_question_interaction(
         value=confidence_value,
         key=confidence_key,
     )
-    st.session_state[confidence_key] = confidence_value
     show_explanation = st.session_state.get(explanation_key, False)
     flagged = row["id"] in set(st.session_state.get("review_flags", []))
     grade_label = "採点"


### PR DESCRIPTION
## Summary
- ensure the confidence slider has a safe default before rendering
- rely on Streamlit's widget state instead of manually reassigning the slider value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db7c0ac5f48323a353dce1fa4a0e0c