### PR TITLE
Ensure markdown content is left aligned

### DIFF
--- a/app.py
+++ b/app.py
@@ -1132,6 +1132,12 @@ def inject_ui_styles() -> None:
 .takken-inline-actions button {
     min-height: 48px;
 }
+[data-testid="stMarkdownContainer"] {
+    text-align: left;
+}
+[data-testid="stMarkdownContainer"] * {
+    text-align: left !important;
+}
 """,
         "takken-ui-styles",
     )


### PR DESCRIPTION
## Summary
- enforce left-aligned typography for markdown-rendered content so answers are easier to read

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db9f7993848323a5ef4cd8bd8d1c77