### PR TITLE
Move sidebar menu to top

### DIFF
--- a/app.py
+++ b/app.py
@@ -1695,6 +1695,15 @@ def main() -> None:
 
     sidebar = st.sidebar
     sidebar.title("宅建10年ドリル")
+    nav = sidebar.radio(
+        "メニュー",
+        ["ホーム", "学習モード", "模試", "弱点復習", "統計", "データ入出力", "設定"],
+        index=["ホーム", "学習モード", "模試", "弱点復習", "統計", "データ入出力", "設定"].index(
+            st.session_state.get("nav", "ホーム")
+        ),
+    )
+    st.session_state["nav"] = nav
+    sidebar.divider()
     sidebar.text_input(
         "🔍 横断検索",
         key="global_search_input",
@@ -1733,13 +1742,6 @@ def main() -> None:
                 set_global_search_query(keyword)
                 search_query = keyword
                 safe_rerun()
-    sidebar.divider()
-    nav = sidebar.radio(
-        "メニュー",
-        ["ホーム", "学習モード", "模試", "弱点復習", "統計", "データ入出力", "設定"],
-        index=["ホーム", "学習モード", "模試", "弱点復習", "統計", "データ入出力", "設定"].index(st.session_state.get("nav", "ホーム")),
-    )
-    st.session_state["nav"] = nav
     with sidebar.expander("モード別の使い方ガイド", expanded=False):
         st.markdown(
             "\n".join(


### PR DESCRIPTION
## Summary
- reposition the sidebar navigation radio group immediately below the title
- insert a divider after the menu so the search section remains separated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba058944c83239ef7aa25b5c442ae