### PR TITLE
Remove redundant rerun calls from callbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,7 +417,6 @@ def safe_rerun() -> None:
 def with_rerun(callback: Callable[..., None], *args, **kwargs) -> Callable[[], None]:
     def _inner() -> None:
         callback(*args, **kwargs)
-        safe_rerun()
 
     return _inner
 


### PR DESCRIPTION
## Summary
- stop invoking `st.rerun` inside widget callbacks to avoid Streamlit's no-op warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf7b0ecfc83238995c444fedb20b2