### PR TITLE
Handle invalid nav session state

### DIFF
--- a/app.py
+++ b/app.py
@@ -2103,12 +2103,14 @@ def main() -> None:
         "統計",
         "設定",
     ]
+    nav_value = st.session_state.get("nav", "ホーム")
+    if nav_value not in menu_options:
+        nav_value = "ホーム"
+        st.session_state["nav"] = nav_value
     sidebar.radio(
         "メニュー",
         menu_options,
-        index=menu_options.index(
-            st.session_state.get("nav", "ホーム")
-        ),
+        index=menu_options.index(nav_value),
         key="_nav_widget",
         on_change=with_rerun(handle_nav_change),
     )


### PR DESCRIPTION
## Summary
- default the navigation session state to "ホーム" when its value is not a known menu option
- reuse the sanitized navigation value for the sidebar radio button to avoid crashes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd096edf3c8323bdc19c8e009edb0a